### PR TITLE
Make the `iconSize` and `studioTheme` parameters optional

### DIFF
--- a/src/init.lua
+++ b/src/init.lua
@@ -3,11 +3,11 @@
 	Created by break-core
 ]]
 
-return function(className: string, iconSize: number, studioTheme: "Light" | "Dark"): string
+return function(className: string, iconSize: number?, studioTheme: "Light" | "Dark"?): string
 	--- Variables
 	className = className
-	iconSize = iconSize
-	studioTheme = studioTheme
+	iconSize = iconSize or 1
+	studioTheme = studioTheme or settings().Studio.Theme.Name
 
 	if className then
 		--- Get the default sized icon


### PR DESCRIPTION
Apologies if I made you mad by "reinventing the wheel" of your module, but I have a pull request to make the `iconSize` and `studioTheme` parameters optional, as `iconSize` IMO oftentimes used as 1, and `studioTheme` should rely on the current theme by using `settings().Studio.Theme.Name`, Hopefully it makes you feel better :)